### PR TITLE
OP_SIGHASH: A simple, flexible introspection opcode

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -35,6 +35,7 @@ enum DeploymentPos : uint16_t {
     DEPLOYMENT_TAPROOT, // Deployment of Schnorr/Taproot (BIPs 340-342)
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in deploymentinfo.cpp
     DEPLOYMENT_CSFS,  // Deployment of CHECKSIGFROMSTACK (BIP 348) (regtest only)
+    DEPLOYMENT_SIGHASH,  // Deployment of OP_SIGHASH (BIP XXX) (regtest only)
     MAX_VERSION_BITS_DEPLOYMENTS
 };
 constexpr bool ValidDeployment(DeploymentPos dep) { return dep < MAX_VERSION_BITS_DEPLOYMENTS; }

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -21,6 +21,10 @@ const std::array<VBDeploymentInfo,Consensus::MAX_VERSION_BITS_DEPLOYMENTS> Versi
         /*.name =*/ "csfs",
         /*.gbt_force =*/ true,
     },
+    {
+        /*.name =*/ "sighash",
+        /*.gbt_force =*/ true,
+    },
 };
 
 std::string DeploymentName(Consensus::BuriedDeployment dep)

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -545,6 +545,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSFS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSFS].min_activation_height = 0; // No activation delay
 
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIGHASH].bit = 3;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIGHASH].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIGHASH].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIGHASH].min_activation_height = 0; // No activation delay
+
         consensus.nMinimumChainWork = uint256{};
         consensus.defaultAssumeValid = uint256{};
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1411,6 +1411,7 @@ UniValue DeploymentInfo(const CBlockIndex* blockindex, const ChainstateManager& 
 
     if (chainman.GetParams().GetChainType() == ChainType::REGTEST) {
         SoftForkDescPushBack(blockindex, softforks, chainman, Consensus::DEPLOYMENT_CSFS);
+        SoftForkDescPushBack(blockindex, softforks, chainman, Consensus::DEPLOYMENT_SIGHASH);
     }
     return softforks;
 }

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -151,6 +151,7 @@ std::string GetOpName(opcodetype opcode)
 
     // Tapscript expansion
     case OP_CHECKSIGFROMSTACK       : return "OP_CHECKSIGFROMSTACK";
+    case OP_SIGHASH                 : return "OP_SIGHASH";
 
     case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -192,6 +192,7 @@ enum opcodetype
     OP_CHECKMULTISIG = 0xae,
     OP_CHECKMULTISIGVERIFY = 0xaf,
     OP_CHECKSIGFROMSTACK = 0xcc,
+    OP_SIGHASH = 0xcd,
 
     // expansion
     OP_NOP1 = 0xb0,

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -72,6 +72,8 @@ static std::map<std::string, unsigned int> mapFlagNames = {
     {std::string("DISCOURAGE_UPGRADABLE_TAPROOT_VERSION"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION},
     {std::string("CHECKSIGFROMSTACK"), (unsigned int)SCRIPT_VERIFY_CHECKSIGFROMSTACK},
     {std::string("DISCOURAGE_CHECKSIGFROMSTACK"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_CHECKSIGFROMSTACK},
+    {std::string("SIGHASH"), (unsigned int)SCRIPT_VERIFY_SIGHASH},
+    {std::string("DISCOURAGE_SIGHASH"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_SIGHASH},
 };
 
 unsigned int ParseScriptFlags(std::string strFlags)

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -455,8 +455,8 @@ BOOST_FIXTURE_TEST_CASE(versionbits_computeblockversion, BlockVersionTest)
             // times are picked.
             const uint32_t dep_mask{uint32_t{1} << chainParams->GetConsensus().vDeployments[dep].bit};
 
-            if (chain_type != ChainType::REGTEST && dep == Consensus::DEPLOYMENT_CSFS) {
-                // CSFS only exists as a deployment on regtest, so skip over it for other
+            if (chain_type != ChainType::REGTEST && (dep == Consensus::DEPLOYMENT_CSFS || dep == Consensus::DEPLOYMENT_SIGHASH)) {
+                // CSFS and SIGHASH only exist as a deployment on regtest, so skip over them for other
                 // chains.
                 continue;
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1233,10 +1233,12 @@ bool MemPoolAccept::PolicyScriptChecks(const ATMPArgs& args, Workspace& ws)
 
     unsigned int scriptVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
 
-    // CHECKSIGFROMSTACK (BIP348) is always active on regtest, but no other chain.
+    // CHECKSIGFROMSTACK (BIP348) and SIGHASH (BIPXXX) are always active on regtest, but no other chain.
     if (args.m_chainparams.GetChainType() == ChainType::REGTEST) {
         scriptVerifyFlags |= SCRIPT_VERIFY_CHECKSIGFROMSTACK;
         scriptVerifyFlags &= ~SCRIPT_VERIFY_DISCOURAGE_CHECKSIGFROMSTACK;
+        scriptVerifyFlags |= SCRIPT_VERIFY_SIGHASH;
+        scriptVerifyFlags &= ~SCRIPT_VERIFY_DISCOURAGE_SIGHASH;
     }
 
     // Check input scripts and signatures.
@@ -2393,6 +2395,11 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
     // Enforce CHECKSIGFROMSTACK (BIP348)
     if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_CSFS)) {
         flags |= SCRIPT_VERIFY_CHECKSIGFROMSTACK;
+    }
+
+    // Enforce OP_SIGHASH (BIPXXX)
+    if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_SIGHASH)) {
+        flags |= SCRIPT_VERIFY_SIGHASH;
     }
 
     // Enforce the DERSIG (BIP66) rule

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -264,6 +264,19 @@ class BlockchainTest(BitcoinTestFramework):
                 },
                 'height': 0,
                 'active': True
+            },
+            'sighash': {
+                'type': 'bip9',
+                'bip9': {
+                    'start_time': -1,
+                    'timeout': 9223372036854775807,
+                    'min_activation_height': 0,
+                    'status': 'active',
+                    'status_next': 'active',
+                    'since': 0,
+                },
+                'height': 0,
+                'active': True
             }
           }
         })


### PR DESCRIPTION
### What it does

`OP_SIGHASH` is a Tapscript-only opcode that computes the transaction's sighash message and pushes it onto the stack. Each part of the sighash message (version, locktime, `m_prevouts_single_hash`, `m_outputs_single_hash`, `m_annex_hash`, etc.) is given a selector between 0 and 15. Users define the selectors they wish to include in their commitment using a bitmap, which is popped off the stack and is at most 2 bytes.

### How it works

This opcode reuses the hashing logic found in `SignatureHashSchnorr()`, minimizing the amount of new code.

To prevent resource abuse, this PR implements a credit system between `CHECKSIGFROMSTACK` and `SIGHASH`. Both decrement the validation weight limit, but each credits one "free" execution of the other. For example, a call to `CSFS` credits one free call to `SIGHASH`, and vice versa. This mirrors the resources used in `CHECKSIG`, which performs both a sighash calculation and a signature verification.

Finally, by default, if the element popped off the stack is empty, the selector `0xFFFF` is used. This equates to `SIGHASH_ALL`.

### Why it's useful

This opcode may be a much more natural complement to `CHECKSIGFROMSTACK` than `CTV`. Whereas `CTV` commits to the same parts of a transaction every time it is used, `SIGHASH` enables much more flexible commitments, including commitments that include the taproot annex, the previous outputs, and/or the output at the same index.

The ability to commit to the taproot annex, excluding the previous outputs, may be particularly useful for Lightning Symmetry, as it could be used with `CSFS` to emulate `ANYPREVOUT`. @instagibbs previously showed how APO with a commitment to the annex could be used to efficiently implement Lightning Symmetry (see Jeremy Rubin's [post](https://rubin.io/bitcoin/2024/12/02/csfs-ctv-rekey-symmetry/)), and I tend to think that `SIGHASH + CSFS` may provide a cleaner and cheaper implementation than `CTV + CSFS`, which requires some opcode magic and the use of an `OP_RETURN`.

Likewise, the ability to commit to a single output, rather than all the outputs in the transaction, may be useful for certain vault and covenant applications. For example, Alice could authorize a 12-month subscription to Bob's service, giving Bob the ability to withdraw up to X sats per month. With `CTV`, Bob would need a second transaction to pay the fees and aggregate other subscription payments, but with `SIGHASH`, Bob could do it all in one transaction. 

It’s also worth pointing out that `SIGHASH` would provide witness malleability protection on tapleaves that lack a signature. A tapleaf with a single `CTV` commitment would be exposed to witness malleability via the annex. In contrast, with `SIGHASH`, the commitment could include a commitment to no annex, preventing witness malleability.

Finally, if `PAIRCOMMIT` or [Graftleaf](https://github.com/joshdoman/bitcoin/pull/1) gets implemented, `SIGHASH` could be used to solve the bidding problem, which requires [mass delegated introspection](https://delvingbitcoin.org/t/how-csfs-paircommit-enables-mass-delegated-introspection/1599). Users could directly authorize many possible sighashes with a single signature, corresponding to many different offers to buy a UTXO-based asset. A seller could then accept the offer by selecting the appropriate sighash. I outlined how this might work with `CSFS+PAIRCOMMIT` in this [Delving Post](https://delvingbitcoin.org/t/how-csfs-paircommit-enables-mass-delegated-introspection/1599), but `SIGHASH` could make the implementation more compact and cost efficient.

### Limitations vs. CTV

`SIGHASH` has two limitations versus `CTV`. First, unlike `CTV`, it cannot be used in a bare scriptPubKey. If this functionality is desirable, it can be added by creating a new witness version for bare tapscript.

Second, unlike `CTV`, `SIGHASH` lacks the ability to commit to the `scriptSigs` in the transaction. Such commitment has limited usefulness, except as a way to commit to a pre-Segwit spent output in the transaction. If this functionality is desirable, I suspect that a less hacky solution can be implemented, such as via a `CHECKPREVOUT` opcode, which checks if a prevout exists in precomputed set of prevouts in the transaction.

### Request for Feedback

I'd appreciate feedback on several aspects of this proposal:

1. **Opcode Design**: Is the flexible bitmap approach to selecting transaction elements the right one? Would a more structured approach with predefined sighash types be preferable?

2. **Credit System**: Does the credit system between `OP_SIGHASH` and `OP_CHECKSIGFROMSTACK` make sense? Are there edge cases or potential abuses I haven't considered?

3. **Use Cases**: I've outlined some potential applications, but I'd appreciate thoughts on other covenant designs that would benefit from this opcode, especially in comparison to alternatives like `OP_CTV`.

4. **Deployment Strategy**: Should this proposal be bundled with `OP_CHECKSIGFROMSTACK` since they complement each other, or should it proceed independently?

5. **Naming**: The opcode is currently named `OP_SIGHASH`, but would a name like `OP_GETSIGHASH` better reflect its functionality?

This is an early draft, and I’m open to making changes based on community feedback. I haven’t yet decided if covenants is even a must-have in Bitcoin, but if CTV-like functionality is desirable, I’m not yet convinced that CTV itself is the best way to achieve that, or the most elegant. Look forward to hearing though what the community thinks!